### PR TITLE
Add `min(_:)` and `max(_:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,10 +404,12 @@ Returns the element with the greatest value for a `Comparable` property.
 
 ```swift
 contacts.max(by: \.age)
+contacts.max(\.age)
 ```
 
 ```
 Optional(Person(firstName: "Charles", lastName: "Webb", age: 45, hasDriverLicense: true, isAmerican: true))
+Optional(45)
 ```
 
 ### min
@@ -416,10 +418,12 @@ Returns the element with the minimum value for a `Comparable` property.
 
 ```swift
 contacts.min(by: \.age)
+contacts.min(\.age)
 ```
 
 ```
 Optional(Person(firstName: "Alex", lastName: "Alexson", age: 8, hasDriverLicense: false, isAmerican: true))
+Optional(8)
 ```
 
 ### or

--- a/Sources/Operators/max.swift
+++ b/Sources/Operators/max.swift
@@ -12,4 +12,8 @@ extension Collection {
     public func max<T: Comparable>(by attribute: KeyPath<Element, T>) -> Element? {
         return self.max(by: { $0[keyPath: attribute] < $1[keyPath: attribute] })
     }
+
+    public func max<T: Comparable>(_ attribute: KeyPath<Element, T>) -> T? {
+        return self.max(by: attribute)?[keyPath: attribute]
+    }
 }

--- a/Sources/Operators/min.swift
+++ b/Sources/Operators/min.swift
@@ -12,4 +12,8 @@ extension Collection {
     public func min<T: Comparable>(by attribute: KeyPath<Element, T>) -> Element? {
         return self.min(by: { $0[keyPath: attribute] < $1[keyPath: attribute] })
     }
+
+    public func min<T: Comparable>(_ attribute: KeyPath<Element, T>) -> T? {
+        return self.min(by: attribute)?[keyPath: attribute]
+    }
 }


### PR DESCRIPTION
Following my previous PR (#10) here are 2 new methods: 

```swift
public func min<T: Comparable>(_ attribute: KeyPath<Element, T>) -> T?
public func max<T: Comparable>(_ attribute: KeyPath<Element, T>) -> T?
```

They find the min / max value and immediately extract it. Here's an example:

```swift
contacts.max(by: \.age)
contacts.max(\.age)

Optional(Person(firstName: "Charles", lastName: "Webb", age: 45, hasDriverLicense: true, isAmerican: true))
Optional(45)
```

```swift
contacts.min(by: \.age)
contacts.min(\.age)

Optional(Person(firstName: "Alex", lastName: "Alexson", age: 8, hasDriverLicense: false, isAmerican: true))
Optional(8)
```