### PR TITLE
Allow any Sequence in `filter(where:in:)` and `filter(where:contains:)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ contacts.filter(where: \.firstName == "Webb")
 
 ### filterIn
 
-Filters out elements whose value for an `Equatable` property is not in a given `Set`.
+Filters out elements whose value for an `Equatable` property is not in a given `Sequence`.
 
 ```swift
 contacts.filter(where: \.firstName, in: ["Alex", "John"])

--- a/Sources/Operators/filterIn.swift
+++ b/Sources/Operators/filterIn.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 extension Sequence {
-    public func filter<S: Sequence, T: Hashable>(where attribute: KeyPath<Element, T>, in values: S) -> [Element] where S.Element == T {
+    public func filter<S: Sequence, T: Equatable>(where attribute: KeyPath<Element, T>, in values: S) -> [Element] where S.Element == T {
         return filter { values.contains($0[keyPath: attribute]) }
     }
 
-    public func filter<S: Sequence, T: Hashable>(where values: S, contains attribute: KeyPath<Element, T>) -> [Element] where S.Element == T {
+    public func filter<S: Sequence, T: Equatable>(where values: S, contains attribute: KeyPath<Element, T>) -> [Element] where S.Element == T {
         return filter { values.contains($0[keyPath: attribute]) }
     }
 }

--- a/Sources/Operators/filterIn.swift
+++ b/Sources/Operators/filterIn.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 extension Sequence {
-    public func filter<T>(where attribute: KeyPath<Element, T>, in values: Set<T>) -> [Element] {
+    public func filter<S: Sequence, T: Hashable>(where attribute: KeyPath<Element, T>, in values: S) -> [Element] where S.Element == T {
         return filter { values.contains($0[keyPath: attribute]) }
     }
 
-    public func filter<T>(where values: Set<T>, contains attribute: KeyPath<Element, T>) -> [Element] {
+    public func filter<S: Sequence, T: Hashable>(where values: S, contains attribute: KeyPath<Element, T>) -> [Element] where S.Element == T {
         return filter { values.contains($0[keyPath: attribute]) }
     }
 }


### PR DESCRIPTION
👋 Hello

It's me again 🙂 
Here's a minor change to allow any kind of Sequence in 2 methods instead of allowing only a `Set<T>`.