### PR TITLE
Update for Xcode 10.2 and Swift 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+.DS_Store

--- a/KeyPathKit.podspec
+++ b/KeyPathKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KeyPathKit'
-  s.version          = '1.5.0'
+  s.version          = '1.5.1'
   s.summary          = 'KeyPathKit leverages Swift 4 KeyPath type in order to implement a SQL-like data manipulation API'
 
   s.description      = <<-DESC

--- a/KeyPathKit.podspec
+++ b/KeyPathKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KeyPathKit'
-  s.version          = '1.4.2'
+  s.version          = '1.5.0'
   s.summary          = 'KeyPathKit leverages Swift 4 KeyPath type in order to implement a SQL-like data manipulation API'
 
   s.description      = <<-DESC

--- a/KeyPathKit.podspec
+++ b/KeyPathKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KeyPathKit'
-  s.version          = '1.4.2'
+  s.version          = '1.5.1'
   s.summary          = 'KeyPathKit leverages Swift 4 KeyPath type in order to implement a SQL-like data manipulation API'
 
   s.description      = <<-DESC

--- a/KeyPathKitTests/TestOperators/dropTests.swift
+++ b/KeyPathKitTests/TestOperators/dropTests.swift
@@ -25,10 +25,10 @@ class DropTests: XCTestCase {
     
     func test_drop_empty() {
         let data: [TestData] = []
-        
-        XCTAssertEqual(data.drop(while: \.bool), [])
-        XCTAssertEqual(data.drop(while: \.bool == true), [])
-        XCTAssertEqual(data.drop(while: \.string == "first"), [])
+    
+        XCTAssertEqual(Array(data.drop(while: \.bool)) , [])
+        XCTAssertEqual(Array(data.drop(while: \.bool == true)), [])
+        XCTAssertEqual(Array(data.drop(while: \.string == "first")), [])
     }
     
     func test_drop_allValues() {

--- a/KeyPathKitTests/TestOperators/groupByTests.swift
+++ b/KeyPathKitTests/TestOperators/groupByTests.swift
@@ -39,10 +39,19 @@ class GroupByTests: XCTestCase {
                     TestData(string: "three", int: 78, bool: false),
                     TestData(string: "one", int: -6, bool: true)]
         
-        let expected = ["one": [TestData(string: "one", int: 2, bool: true), TestData(string: "one", int: 32, bool: true), TestData(string: "one", int: -6, bool: true)],
-                        "two": [TestData(string: "two", int: 45, bool: false), TestData(string: "two", int: 19, bool: false)],
+        let expected = ["one": [TestData(string: "one", int: 2, bool: true),
+                                TestData(string: "one", int: 32, bool: true),
+                                TestData(string: "one", int: -6, bool: true)],
+                        
+                        "two": [TestData(string: "two", int: 45, bool: false),
+                                TestData(string: "two", int: 19, bool: false)],
+                        
                         "three": [TestData(string: "three", int: 78, bool: false)]]
         
-        XCTAssert(data.groupBy(\.string) == expected)
+        // In dictionnary sorting doesn't matters.
+        expected.forEach { (key, value) in
+            
+            XCTAssert(expected[key] == value)
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ contacts.sorted(by: \.age)
 It's also possible to specify the sorting order, to sort on multiple criteria, or to do both.
 
 ```swift
-contacts.sorted(by: .ascending(\. lastName), .descending(\.age))
+contacts.sorted(by: .ascending(\.lastName), .descending(\.age))
 ```
 
 ```

--- a/Sources/Operators/drop.swift
+++ b/Sources/Operators/drop.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Sequence {
-    public func drop(while attribute: KeyPath<Element, Bool>) -> Self.SubSequence {
+    public func drop(while attribute: KeyPath<Element, Bool>) -> DropWhileSequence<Self> {
         return drop(while: { $0[keyPath: attribute] })
     }
 }

--- a/Sources/Operators/prefix.swift
+++ b/Sources/Operators/prefix.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Sequence {
-    public func prefix(while attribute: KeyPath<Element, Bool>) -> Self.SubSequence {
+    public func prefix(while attribute: KeyPath<Element, Bool>) -> [Self.Element] {
         return prefix(while: { $0[keyPath: attribute] })
     }
 }

--- a/Sources/SingleTypePredicate/dropPredicate.swift
+++ b/Sources/SingleTypePredicate/dropPredicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Sequence {
-    public func drop(while predicate: KeyPathSingleTypePredicate<Element>) -> Self.SubSequence {
-        return drop(while: { predicate.evaluate(for: $0) })
+    public func drop(while predicate: KeyPathSingleTypePredicate<Element>) ->  DropWhileSequence<Self> {
+        return drop(while: { predicate.evaluate(for: $0) }) 
     }
 }

--- a/Sources/SingleTypePredicate/prefixPredicate.swift
+++ b/Sources/SingleTypePredicate/prefixPredicate.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 extension Sequence {
-    public func prefix(while predicate: KeyPathSingleTypePredicate<Element>) -> Self.SubSequence {
+    public func prefix(while predicate: KeyPathSingleTypePredicate<Element>) -> [Self.Element] {
         return prefix(while: { predicate.evaluate(for: $0) })
     }
 }


### PR DESCRIPTION
In swift 5 SubSequence have been removed and replaced by DropWhileSequence or Array of Sequence.Element.

Unit testing have been also updated for DropWhileSequence compliance.
GroupTest have been updated: Sorting doesn't matter in dictionaries.

+ DS_Store has been added to .gitignore file.

Merci ;) 